### PR TITLE
Working basic tempest. 

### DIFF
--- a/manifests/profiles/openstack/tempest.pp
+++ b/manifests/profiles/openstack/tempest.pp
@@ -1,0 +1,16 @@
+class coi::profiles::openstack::tempest (
+  $identity_host  = hiera('controller_node_public'),
+  $admin_password = hiera('admin_password'),
+  $image_host     = hiera('controller_node_public'),
+)
+{
+    class { '::tempest':
+      require => [ Service['keystone'],
+                   Service['glance-api'],
+                   Service['glance-registry']
+                 ],
+      identity_host  => $identity_host,
+      admin_password => $admin_password,
+      image_host     => $image_host
+    }
+}

--- a/manifests/roles/controller.pp
+++ b/manifests/roles/controller.pp
@@ -1,6 +1,4 @@
 class coi::roles::controller {
-
   include coi::profiles::openstack::controller
   include coi::profiles::openstack::test_file
-  include coi::profiles::openstack::tempest
 }

--- a/manifests/roles/controller.pp
+++ b/manifests/roles/controller.pp
@@ -2,5 +2,5 @@ class coi::roles::controller {
 
   include coi::profiles::openstack::controller
   include coi::profiles::openstack::test_file
-
+  include coi::profiles::openstack::tempest
 }

--- a/manifests/roles/controller/tempest.pp
+++ b/manifests/roles/controller/tempest.pp
@@ -1,0 +1,8 @@
+#
+# Installs the usual control server
+# plus the tempest test suite
+#
+class coi::roles::controller::tempest {
+  include coi::roles::controller
+  include coi::profiles::openstack::tempest
+}


### PR DESCRIPTION
Will conflict due to duplicate pip which needs to be fixed in the tempest module - change pip to python-setuptools (this is done in Manu's patch) or use ensure_package/resource or something (less lame).

I'm not sure this patch is the right thing to do, since it would be putting tempest on every controller node, and that's probably not so good for actual deployments. I'll move it into a separate role.

I have the service requires because require => Class[::openstack::controller] didn't seem to work - it was trying to add glance images before glance had been brought up. Is that what you would expect?
