### PR TITLE
Modify pip2pi path and params

### DIFF
--- a/manifests/profiles/params.pp
+++ b/manifests/profiles/params.pp
@@ -5,10 +5,8 @@ class coi::profiles::params {
 
   case $::osfamily {
     'Redhat': {
-      $pip2pi_path = "/usr/local/bin/pip2pi"
     }
     'Debian': {
-      $pip2pi_path = "/usr/bin/pip2pi"
     }
     default: {
       fail("unsupported osfamily: $::osfamily")


### PR DESCRIPTION
pip2pi in the cache_server.pp was a hard coded link, and the "creates" command was incorrect for Debian.  This was updated with a more globally scoped path, and a "which app" unless check rather than a pointed creates which
seems to have a potential to change.
