### PR TITLE
inherit params from build_server roles

### DIFF
--- a/manifests/roles/build_server.pp
+++ b/manifests/roles/build_server.pp
@@ -5,7 +5,8 @@ class coi::roles::build_server (
   $enable_cobbler      = hiera('enable_cobbler', $::coi::roles::params::enable_cobbler),
   $enable_cache        = hiera('enable_cache', $::coi::roles::params::enable_cache),
   $enable_monitoring   = hiera('enable_monitoring', true),
-  ){
+) inherits coi::roles::params {
+
   include coi::profiles::puppet::master
 
   if ($enable_monitoring) {


### PR DESCRIPTION
Previously, the build_server role was using params
as class param defaults, but not inheriting them (and
thus not initializing the params class namespace)

This resulted in the enable_cobbler and enable_cache
parameters always being evaluated as false.

This commit adds the inheritance of params so that things
are evaluated correctly.
