### PR TITLE
Don't set ensure.

### DIFF
--- a/manifests/profiles/base.pp
+++ b/manifests/profiles/base.pp
@@ -12,7 +12,6 @@ class coi::profiles::base(
 
   class { ntp:
     servers    => $ntp_servers,
-    ensure     => running,
     autoupdate => true,
   }
 


### PR DESCRIPTION
The default value is already 'running' so we don't have to set it.
