### PR TITLE
Ensure swift public ip is set correctly

### DIFF
--- a/manifests/profiles/openstack/swift/proxy.pp
+++ b/manifests/profiles/openstack/swift/proxy.pp
@@ -15,10 +15,12 @@ class coi::profiles::openstack::swift::proxy(
   $swift_user_password     = hiera('swift_user_password'),
   $controller_node_address = hiera('controller_node_address'),
   $swift_public_address    = hiera('swift_public_address'),
+  $swift_internal_address  = hiera('swift_local_net_ip'),
 ) {
 
   class {'::openstack::swift::proxy':
-    swift_local_net_ip      => $swift_public_address,
+    swift_proxy_net_ip      => $swift_public_address,
+    swift_local_net_ip      => $swift_internal_address,
     keystone_host           => $controller_node_address,
     controller_node_address => $controller_node_address,
     swift_user_password     => $swift_user_password,


### PR DESCRIPTION
Previously, the swift proxy's public and internal
address were set to be the same.

This commit ensures that swift's public proxy address
is set so that it does not set to eth0 by default.
