### PR TITLE
Allow cobbler nodes to be created as yaml

### DIFF
--- a/manifests/profiles/cobbler_server.pp
+++ b/manifests/profiles/cobbler_server.pp
@@ -103,8 +103,11 @@ class coi::profiles::cobbler_server(
   $ip               = hiera('cobbler_ip', false),
   $dns_service      = hiera('dns_service', 'dnsmasq'),
   $dhcp_service     = hiera('dhcp_service', 'dnsmasq'),
+  $nodes            = hiera('cobbler_nodes', {}),
 ) inherits coi::profiles::base {
 
+  # create all of the managed nodes
+  create_resources('coi::cobbler_node', $nodes)
 
   if ! $node_dns {
     $node_dns_real = $cobbler_node_ip


### PR DESCRIPTION
This commit adds a nodes variable to the
cobbler_server profile that can be used to
consume a hash of cobbler nodes defined in
hiera under the key: cobbler_nodes.

This change is made for two reasons:
1. the cobbler profile should be responsible for
   configuring its own nodes
2. it ensures that cobbler nodes are only configured
   when cobbler is configured.
