### PR TITLE
Add apache profile

### DIFF
--- a/manifests/profiles/apache.pp
+++ b/manifests/profiles/apache.pp
@@ -1,0 +1,10 @@
+#
+# this profile can be used by
+# other components to install their apache
+# service.
+#
+class coi::profiles::apache {
+  class { '::apache':
+    mpm_module => 'prefork',
+  }
+}

--- a/manifests/profiles/cache_server.pp
+++ b/manifests/profiles/cache_server.pp
@@ -10,11 +10,11 @@ class coi::profiles::cache_server(
   $default_gateway = hiera('default_gateway', false),
   $proxy           = hiera('proxy', undef)
 ) inherits coi::profiles::base {
- 
+
   Exec {
     path => ['/bin','/usr/bin','/sbin','/usr/sbin','/usr/local/bin']
   }
- 
+
   class { apt-cacher-ng:
     proxy     => $proxy,
     avoid_if_range  => true, # Some proxies have issues with range headers
@@ -65,7 +65,7 @@ class coi::profiles::cache_server(
     }
 
 
-   include apache
+   include coi::profiles::apache
 
    #
    # TODO - this is one of the few differneces between this and ciscos code

--- a/manifests/profiles/monitoring_server.pp
+++ b/manifests/profiles/monitoring_server.pp
@@ -8,6 +8,8 @@ class coi::profiles::monitoring_server(
   #$graphitehost  => hiera('build_node_fqdn', $::fqdn)
 )  inherits coi::profiles::base {
 
+  include coi::profiles::apache
+
   class { 'naginator': }
 
   class { 'graphite':

--- a/manifests/profiles/puppet/master.pp
+++ b/manifests/profiles/puppet/master.pp
@@ -16,6 +16,7 @@ class coi::profiles::puppet::master inherits coi::profiles::base {
   # the cisco ones. Perhaps whether or
   # not to use these should be a hiera lookup?
   include puppet::repo::puppetlabs
+  include coi::profiles::apache
 
   # the puppetdb package should not be installed
   # before our certificate is generated


### PR DESCRIPTION
This commit adds an apache profile which serves
as a central location to configure apache so that
it can be configured, and still used as a dependency
for multiple services.

This change is required b/c of 41b0a42b07f6681e01363d7d5738e5f46d747f64
from naginator which includes apache::mod::php which requires
that apache is configured to use prefork to manage processes.
