### PR TITLE
do not set authtoken

### DIFF
--- a/manifests/profiles/openstack/auth_file.pp
+++ b/manifests/profiles/openstack/auth_file.pp
@@ -5,7 +5,6 @@
 #
 class coi::profiles::openstack::auth_file (
   $admin_password           = hiera('admin_password'),
-  $keystone_admin_token     = hiera('keystone_admin_token'),
   $controller_node_internal = hiera('controller_node_internal')
 ) {
 
@@ -15,11 +14,10 @@ class coi::profiles::openstack::auth_file (
   class { 'openstack::client':
     ceilometer => false,
   }
-  
+
 
   class { '::openstack::auth_file':
     admin_password       => $admin_password,
-    keystone_admin_token => $keystone_admin_token,
     controller_node      => $controller_node_internal,
   }
 


### PR DESCRIPTION
The config of openrc was updated to either
configure the admin user or auth_token but
not both. This change was made b/c configuring
both caused the keystone providers to break.

This commit removes the configuration logic for
the keystone token environment variables.
