### PR TITLE
Fix modulepath in puppet master

### DIFF
--- a/manifests/profiles/puppet/master.pp
+++ b/manifests/profiles/puppet/master.pp
@@ -45,7 +45,7 @@ class coi::profiles::puppet::master (
   class { '::puppet::master':
     certname    => $::fqdn,
     autosign    => true,
-    modulepath  => '/etc/puppet/modules',
+    modulepath  => '/etc/puppet/modules:/usr/share/puppet/modules',
   }
 
   # install puppetdb and postgresql


### PR DESCRIPTION
When installing a puppet master on the build node, the modulepath
has been getting set with a single path (/etc/puppet/modules).
Puppet typically defaults to both that path and
/usr/share/puppet/modules.  Since most of our packages install
in the latter path, this is problematic.  This commit adds
the missing second path.

Closes-Bug: #1262003
