### PR TITLE
Fixed meaningless floating ';' in late_command

### DIFF
--- a/manifests/profiles/cobbler_server.pp
+++ b/manifests/profiles/cobbler_server.pp
@@ -139,7 +139,7 @@ class coi::profiles::cobbler_server(
   if ($interface_bonding == 'true'){
     $bonding = "echo 'bonding' >> /target/etc/modules"
   } else {
-    $bonding = ''
+    $bonding = 'echo "no bonding configured"'
   }
 
   $interfaces_file=regsubst(template('coi/interfaces.erb'), '$', "\\n\\", "G")


### PR DESCRIPTION
In cases where bonding isn't configured, the late_command was
left with a floating ' ; \' which may have been causing an
error in the installer of the form:
log-output: sh: syntax error: unexpected ";"

This commit restores a more meaningful message from Grizzly which
makes debugging easier and helps avoid the error.

Partial-Bug: #1263310
