### PR TITLE
Move rubygem install into cobbler_server.pp

### DIFF
--- a/manifests/profiles/cobbler_server.pp
+++ b/manifests/profiles/cobbler_server.pp
@@ -158,7 +158,7 @@ class coi::profiles::cobbler_server(
   cobbler::ubuntu::preseed { "cisco-preseed":
     admin_user       => $admin_user,
     password_crypted => $password_crypted,
-    packages         => "openssh-server vim vlan lvm2 ntp puppet",
+    packages         => "openssh-server vim vlan lvm2 ntp puppet rubygems",
     ntp_server       => $build_node_fqdn,
     late_command     => sprintf('
 sed -e "/logdir/ a pluginsync=true" -i /target/etc/puppet/puppet.conf ; \


### PR DESCRIPTION
Previously we installed rubygems via a static line in a static
preseed file.  This commit consolidates package installs by
putting rubygems in the same place in the manifests as other
packages.  The entry in the static file (and indeed the static
file itself) will be removed in a subsequent commit to
puppet-cobbler.  Until that commit goes in, this commit hurts
nothing and is merely a bit redundant.

Partial-Bug: #1263310
