### PR TITLE
Don't install puppet until Cisco repo is set up

### DIFF
--- a/manifests/profiles/cobbler_server.pp
+++ b/manifests/profiles/cobbler_server.pp
@@ -158,7 +158,7 @@ class coi::profiles::cobbler_server(
   cobbler::ubuntu::preseed { "cisco-preseed":
     admin_user       => $admin_user,
     password_crypted => $password_crypted,
-    packages         => "openssh-server vim vlan lvm2 ntp puppet rubygems",
+    packages         => "openssh-server vim vlan lvm2 ntp rubygems",
     ntp_server       => $build_node_fqdn,
     late_command     => sprintf('
 sed -e "/logdir/ a pluginsync=true" -i /target/etc/puppet/puppet.conf ; \


### PR DESCRIPTION
Due to a change in puppet-cobbler to fix an issue with repository
definition duplication, we need to defer the installation
of Puppet until late_command (so that the Cisco repo can be set up
before Puppet is installed).  This patch does that by removing
Puppet from the install list and letting puppet-cobbler handle
it in late_command.

Partial-Bug: #1265850
