### PR TITLE
Add ability to set time zone

### DIFF
--- a/manifests/profiles/cobbler_server.pp
+++ b/manifests/profiles/cobbler_server.pp
@@ -110,6 +110,7 @@ class coi::profiles::cobbler_server(
   $dns_service      = hiera('dns_service', 'dnsmasq'),
   $dhcp_service     = hiera('dhcp_service', 'dnsmasq'),
   $nodes            = hiera('cobbler_nodes', {}),
+  $time_zone        = hiera('time_zone', 'UTC'),
 
   # If you want to ensure that a specific Ubuntu kernel version is installed
   # and that it is the default GRUB boot selection when nodes boot for the
@@ -208,6 +209,7 @@ in-target /usr/sbin/update-grub ; "
     password_crypted => $password_crypted,
     packages         => "openssh-server vim vlan lvm2 ntp rubygems",
     ntp_server       => $build_node_fqdn,
+    time_zone        => $time_zone,
     late_command     => sprintf('
 sed -e "/logdir/ a pluginsync=true" -i /target/etc/puppet/puppet.conf ; \
 sed -e "/logdir/ a server=%s" -i /target/etc/puppet/puppet.conf ; \

--- a/manifests/profiles/cobbler_server.pp
+++ b/manifests/profiles/cobbler_server.pp
@@ -110,6 +110,7 @@ class coi::profiles::cobbler_server(
   $dns_service      = hiera('dns_service', 'dnsmasq'),
   $dhcp_service     = hiera('dhcp_service', 'dnsmasq'),
   $nodes            = hiera('cobbler_nodes', {}),
+  $time_zone        = hiera('time_zone', 'UTC'),
 ) inherits coi::profiles::base {
 
   # create all of the managed nodes
@@ -166,6 +167,7 @@ class coi::profiles::cobbler_server(
     password_crypted => $password_crypted,
     packages         => "openssh-server vim vlan lvm2 ntp rubygems",
     ntp_server       => $build_node_fqdn,
+    time_zone        => $time_zone,
     late_command     => sprintf('
 sed -e "/logdir/ a pluginsync=true" -i /target/etc/puppet/puppet.conf ; \
 sed -e "/logdir/ a server=%s" -i /target/etc/puppet/puppet.conf ; \


### PR DESCRIPTION
In Grizzly releases we had an option in site.pp to allow users
to specify the time zone they were in.  This commit adds
a hiera lookup for the time_zone option and passes it on to
the cobbler manifests accordingly.

Partial-Bug: #1263310
