### PR TITLE
Fix erroneous hiera lookup affecting pip

### DIFF
--- a/manifests/profiles/openstack/base.pp
+++ b/manifests/profiles/openstack/base.pp
@@ -12,7 +12,7 @@ class coi::profiles::openstack::base (
   $openstack_repo_location  = hiera('openstack_repo_location', false),
   $ubuntu_repo              = hiera('openstack_ubuntu_repo', 'updates'),
   # optional external services
-  $default_gateway          = hiera('default_gateway', false),
+  $default_gateway          = hiera('node_gateway', false),
   $proxy                    = hiera('proxy', false),
   $public_interface         = hiera('public_interface')
 ) inherits coi::profiles::base {


### PR DESCRIPTION
TL;DR this patch fixes an erroneous hiera lookup caused by a
variable name change between Grizzly and Havana.  We're doing a
lookup for 'default_gateway' when in fact the yaml data uses
'node_gateway'.  This impacts the setup for pip as it will always
see the variable as undef.  More info on the history of this issue
at: https://bugs.launchpad.net/openstack-cisco/+bug/1267942

Closes-Bug: #1267942
