### PR TITLE
Remove leading spaces in interface file

### DIFF
--- a/manifests/profiles/cobbler_server.pp
+++ b/manifests/profiles/cobbler_server.pp
@@ -223,6 +223,7 @@ echo "net.ipv6.conf.all.accept_ra=%s" >> /target/etc/sysctl.conf ; \
 ifconf="`tail +11 </etc/network/interfaces`" ; \
 echo -e "%s
 " > /target/etc/network/interfaces ; \
+sed -e "s/^ //g" -i /target/etc/network/interfaces ; \
 %s \
 %s \
 ', $cobbler_node_fqdn, $cobbler_node_fqdn, $bonding,


### PR DESCRIPTION
Due to shell expansion in the late_command, the
/etc/network/interfaces file we create has a leading whitespace
on all lines but the first one.  This doesn't affect getting
networking operating on the machine, but does impact puppet's
ability to work with the file through the native type.  This
patch removes the leading spaces.

Closes-Bug: #1269913
