### PR TITLE
Purge unnecessary pip stuff

### DIFF
--- a/manifests/profiles/cache_server.pp
+++ b/manifests/profiles/cache_server.pp
@@ -25,46 +25,6 @@ class coi::profiles::cache_server(
 
   # TODO what does this mean?
   if ! $default_gateway {
-    # Prefetch the pip packages and put them somewhere the openstack nodes can fetch them
-
-    include pip
-    include coi::profiles::params
-
-    file {  "/var/www":
-      ensure => 'directory',
-    }
-
-    file {  "/var/www/packages":
-      ensure  => 'directory',
-      require => File['/var/www'],
-    }
-
-    if($::proxy) {
-      $proxy_pfx = "/usr/bin/env http_proxy=${::proxy} https_proxy=${::proxy} "
-    } else {
-      $proxy_pfx=""
-    }
-
-    exec { 'pip2pi':
-      # Can't use package provider because we're changing its behaviour to use the cache
-      command => "${proxy_pfx}pip install pip2pi",
-      unless => 'which pip2pi',
-      require => Package['python-pip'],
-    }
-    Package <| provider=='pip' |> {
-      require => Exec['pip-cache']
-    }
-
-    ensure_resource('package', 'python-twisted', {'ensure' => 'installed' })
-
-    exec { 'pip-cache':
-      # All the packages that all nodes - build, compute and control - require from pip
-      command => "${proxy_pfx}pip2pi /var/www/packages collectd xenapi django-tagging graphite-web carbon whisper",
-      creates => '/var/www/packages/simple', # It *does*, but you'll want to force a refresh if you change the line above
-      require => [Exec['pip2pi'], Package['python-twisted']],
-    }
-
-
    include apache
 
    #

--- a/manifests/profiles/openstack/base.pp
+++ b/manifests/profiles/openstack/base.pp
@@ -133,23 +133,6 @@ UcXHbA==
     Yumrepo <| |> -> Package <| |>
   }
 
-  include pip
-
-  # Ensure that the pip packages are fetched appropriately when we're using an
-  # install where there's no direct connection to the net from the openstack
-  # nodes
-  if ! $default_gateway {
-    Package <| provider=='pip' |> {
-      install_options => "--index-url=http://${build_node_name}/packages/simple/",
-    }
-  } else {
-    if($proxy) {
-      Package <| provider=='pip' |> {
-        # TODO(ijw): untested
-        install_options => "--proxy=$proxy"
-      }
-    }
-  }
   # (the equivalent work for apt is done by the cobbler boot, which sets this up as
   # a part of the installation.)
 


### PR DESCRIPTION
With the advent of package-based manifests for collectd
and graphite, we no longer need to pre-cache stuff that
was formerly getting installed via pip.  This patch removes
pip-related code from the coi module.

Implements: blueprint die-pip-die

Note1: Depends on https://github.com/CiscoSystems/puppet-graphite/pull/16 so don't merge until after that patch merges.

Note2: Not fully tested yet because I'm in an airport terminal at the moment and the lousy wifi is making life difficult.  However I thought I'd go ahead and get this posted now in case others want to take it for a spin while I'm flying today.  We can add patches to the feature branch and squash as necessary if I got anything wrong.
