### PR TITLE
Resolve deprecation warning from NTP module

### DIFF
--- a/manifests/profiles/base.pp
+++ b/manifests/profiles/base.pp
@@ -3,7 +3,7 @@
 # that should be applied to all nodes
 #
 # == Parameters
-#   [ntp_server]
+#   [ntp_servers]
 #     List of ntp servers to use for time synchronization.
 #
 class coi::profiles::base(
@@ -11,8 +11,7 @@ class coi::profiles::base(
 ) {
 
   class { ntp:
-    servers    => $ntp_servers,
-    autoupdate => true,
+    servers => $ntp_servers,
   }
 
   #


### PR DESCRIPTION
```
Resolve deprecation warning from NTP module

Some time back the folks at Puppet Labs deprecated the autoupdate
parameter to the NTP module.  However puppet-coi still invokes
it, which causes a deprecation warning to be emitted:

Notice: Scope(Class[Ntp]): autoupdate parameter has been deprecated
  and replaced with package_ensure.  Set this to latest for the
  same behavior as autoupdate => true.

This patch eliminates the deprecation warning by removing the
deprecated parameter from our instantiation of the class.  A
corresponding change to puppet_openstack_builder will be submitted
to map the package_ensure parameter to a variable used to manage
a similar setting in other OpenStack classes.
```
