### PR TITLE
Allow icehouse cobbler server to serve trusty images

### DIFF
--- a/manifests/profiles/cobbler_server.pp
+++ b/manifests/profiles/cobbler_server.pp
@@ -313,8 +313,13 @@ sed -e "s/^ //g" -i /target/etc/network/interfaces ; \
   }
 
   # This will load the Ubuntu Server OS into cobbler
-  # COE supprts only Ubuntu precise x86_64
+  # COI uses precise for Essex through Havana, and trusty for Icehouse
+
   cobbler::ubuntu { "precise":
+    proxy => $proxy,
+  }
+
+  cobbler::ubuntu { "trusty":
     proxy => $proxy,
   }
 }


### PR DESCRIPTION
Add the trusty profile to the icehouse cobbler server to allow use of
havana build servers to deploy machines for icehouse testing.

Partial-Bug: #1290508
