### PR TITLE
Wrap host definition in if statement

### DIFF
--- a/manifests/profiles/cobbler_server.pp
+++ b/manifests/profiles/cobbler_server.pp
@@ -250,9 +250,11 @@ in-target /usr/sbin/update-grub ; "
 
   ##### START CONFIGURATION #####
 
-  host { $build_node_fqdn:
-    host_aliases => $build_node_name,
-    ip           => $cobbler_node_ip
+  if ! Host["$build_node_fqdn"] {
+    host { $build_node_fqdn:
+      host_aliases => $build_node_name,
+      ip           => $cobbler_node_ip
+    }
   }
 
   ####### Preseed File Configuration #######


### PR DESCRIPTION
Wrap host statement for build_host_fqdn in an if
statement to protect against it having been set
elsewhere (or rather to protect against a host of
equivalent FQDN having been defined previously)
