### PR TITLE
Allow parameterizing autosign and modulepath for puppet master

### DIFF
--- a/manifests/profiles/base.pp
+++ b/manifests/profiles/base.pp
@@ -2,5 +2,5 @@
 # this class stores base configurations
 # that should be applied to all nodes
 #
-class coi::profiles::base(
+class coi::profiles::base{
 }

--- a/manifests/profiles/base.pp
+++ b/manifests/profiles/base.pp
@@ -2,21 +2,5 @@
 # this class stores base configurations
 # that should be applied to all nodes
 #
-# == Parameters
-#   [ntp_servers]
-#     List of ntp servers to use for time synchronization.
-#
 class coi::profiles::base(
-  $ntp_servers = hiera('ntp_servers'),
-) {
-
-  class { ntp:
-    servers => $ntp_servers,
-  }
-
-  #
-  # TODO I need to look more into this file to ensure
-  # that it should be applied everywhere
-  class { "naginator::base_target": }
-
 }

--- a/manifests/profiles/monitoring_server.pp
+++ b/manifests/profiles/monitoring_server.pp
@@ -16,4 +16,9 @@ class coi::profiles::monitoring_server(
     gr_apache_port   => 8190,
  #  graphitehost  => $graphitehost,
   }
+
+  class { 'collectd':
+    #graphitehost         => $build_node_fqdn,
+    #management_interface => $public_interface,
+  }
 }

--- a/manifests/profiles/openstack/base.pp
+++ b/manifests/profiles/openstack/base.pp
@@ -136,8 +136,4 @@ UcXHbA==
   # (the equivalent work for apt is done by the cobbler boot, which sets this up as
   # a part of the installation.)
 
-  class { 'collectd':
-    #graphitehost         => $build_node_fqdn,
-    #management_interface => $public_interface,
-  }
 }

--- a/manifests/profiles/puppet/master.pp
+++ b/manifests/profiles/puppet/master.pp
@@ -31,6 +31,8 @@ class coi::profiles::puppet::master (
   $puppetdb_ssl_port       = 8081,
 ) inherits coi::profiles::base {
 
+  include ::puppet::master
+
   $puppet_master_bind_address = hiera('puppet_master_address', $::fqdn)
   # installs puppet
   # I think I want to assume a puppet 3.x install
@@ -59,13 +61,6 @@ class coi::profiles::puppet::master (
     use_ssl         => false,
     timeout         => 240,
     notify          => Class['apache'],
-  }
-
-  # install puppet master
-  class { '::puppet::master':
-    certname    => $::fqdn,
-    autosign    => hiera('puppet::master::autosign', true),
-    modulepath  => hiera('puppet::master::modulepath', '/etc/puppet/modules:/usr/share/puppet/modules'),
   }
 
   # install puppetdb and postgresql

--- a/manifests/profiles/puppet/master.pp
+++ b/manifests/profiles/puppet/master.pp
@@ -64,8 +64,8 @@ class coi::profiles::puppet::master (
   # install puppet master
   class { '::puppet::master':
     certname    => $::fqdn,
-    autosign    => true,
-    modulepath  => '/etc/puppet/modules:/usr/share/puppet/modules',
+    autosign    => hiera('puppet::master::autosign', true),
+    modulepath  => hiera('puppet::master::modulepath', '/etc/puppet/modules:/usr/share/puppet/modules'),
   }
 
   # install puppetdb and postgresql


### PR DESCRIPTION
Allow overriding arguments to the `puppet::master` class by looking up the arguments in hiera, and falling back to the previous defaults if nothing is found.
