### PR TITLE
Fix duplicate resource error in host definition

### DIFF
--- a/manifests/profiles/cobbler_server.pp
+++ b/manifests/profiles/cobbler_server.pp
@@ -250,10 +250,11 @@ in-target /usr/sbin/update-grub ; "
 
   ##### START CONFIGURATION #####
 
-  host { $build_node_fqdn:
+  ensure_resource ( 'host', $build_node_fqdn, {
     host_aliases => $build_node_name,
     ip           => $cobbler_node_ip
-  }
+    }
+  )
 
   ####### Preseed File Configuration #######
   cobbler::ubuntu::preseed { "cisco-preseed":


### PR DESCRIPTION
If cobbler is enabled on AIO, a duplicate resource error
occurs due to a host defintion being added both by the
coe::base class and the coi::profiles::cobbler_server class.
This patche modifes the cobbler_server class to use
ensure_resource instead of creating the resource directly.

Closes-Bug: #1291068
(cherry picked from commit 97acc80b488597ab858e6cd0b83a20989e45e722)
