### PR TITLE
Drop usage of naginator classes

### DIFF
--- a/manifests/profiles/base.pp
+++ b/manifests/profiles/base.pp
@@ -14,9 +14,4 @@ class coi::profiles::base(
     servers => $ntp_servers,
   }
 
-  #
-  # TODO I need to look more into this file to ensure
-  # that it should be applied everywhere
-  class { "naginator::base_target": }
-
 }

--- a/manifests/profiles/monitoring_server.pp
+++ b/manifests/profiles/monitoring_server.pp
@@ -10,8 +10,6 @@ class coi::profiles::monitoring_server(
 
   include apache
 
-  class { 'naginator': }
-
   class { 'graphite':
     gr_apache_port   => 8190,
  #  graphitehost  => $graphitehost,


### PR DESCRIPTION
Drop use of naginator classes in COI profiles.

Closes-Bug: #1295248
(cherry picked from commit 606e3ce73f38c5fdb4193d3056bfee440fddef8b)
