### PR TITLE
Remove rubygems from preseed

### DIFF
--- a/manifests/profiles/cobbler_server.pp
+++ b/manifests/profiles/cobbler_server.pp
@@ -260,7 +260,7 @@ in-target /usr/sbin/update-grub ; "
   cobbler::ubuntu::preseed { "cisco-preseed":
     admin_user              => $admin_user,
     password_crypted        => $password_crypted,
-    packages                => "openssh-server vim vlan lvm2 ntp rubygems",
+    packages                => "openssh-server vim vlan lvm2 ntp",
     ntp_server              => $build_node_fqdn,
     time_zone               => $time_zone,
     openstack_release       => $openstack_release,


### PR DESCRIPTION
Remove the rubygems package install from the preseed to avoid ruby
version conflicts.

Closes-Bug: #1311102
