### PR TITLE
Trusty composition of puppet / passenger config

### DIFF
--- a/manifests/profiles/puppet/master.pp
+++ b/manifests/profiles/puppet/master.pp
@@ -1,110 +1,40 @@
+# Wrapper class to get puppetmaster, puppetdb, passenger, and Apache configured
 #
-# this profile configures a machine
-# as a puppetmaster.
+
+class coi::profiles::puppet::master(
+  $puppetdb_listen_address    = '0.0.0.0',
+  $puppetdb_port              = 8083,
+  $puppetdb_ssl_port          = 8081,
+  $puppetdb_database_password = 'datapass',
+  $puppet_master_bind_address = hiera('puppet_master_address', $::fqdn),
+  $modulepath                 = '/etc/puppet/modules:/usr/share/puppet/modules',
+  $pluginsync                 = true,
+  $autosign                   = true,
+  $manifest                   = '/etc/puppet/manifests/site.pp',
+) {
+
+  class { 'coi::profiles::puppet::masterpassenger':
+    modulepath => $modulepath,
+    pluginsync => $pluginsync,
+    autosign   => $autosign,
+    certname   => $puppet_master_bind_address,
+    manifest   => $manifest,
+  }
+
+  class { 'coi::profiles::puppet::masterpuppetdb':
+    puppetdb_listen_address    => $puppetdb_listen_address,
+    puppetdb_port              => $puppetdb_port,
+    puppetdb_ssl_port          => $puppetdb_ssl_port,
+    puppetdb_database_password => $puppetdb_database_password,
+    puppet_master_bind_address => $puppet_master_bind_address,
+  }
+
 #
-# [*puppetlabs_repo*]
-# (optional) Sets the apt/yum repository from which
-# puppet master will be installed to be puppetlabs
-# Default: true
+# configure passenger before puppetdb
+  Class['coi::profiles::puppet::masterpassenger'] -> Class['coi::profiles::puppet::masterpuppetdb']
+
 #
-# [*puppetdb_listen_address*]
-# (optional) Sets the hostname or IP address on which
-# PuppetDB will listen.
-# Default: 0.0.0.0
-#
-# [*puppetdb_port*]
-# (optional) Sets the port on which puppetdb should listen
-# for unencrypted incoming connections.  Note that port
-# 8080 is used by Swift proxy, so this is set to 8083 by
-# default to avoid conflicts.
-# Default: 8083
-#
-# [*puppetdb_ssl_port*]
-# (optional) Sets the port on which puppetdb should listen
-# for encrypted incoming connections.
-# Default: 8081
-
-class coi::profiles::puppet::master (
-  $puppetlabs_repo         = hiera('puppetlabs_repo', true),
-  $puppetdb_listen_address = '0.0.0.0',
-  $puppetdb_port           = 8083,
-  $puppetdb_ssl_port       = 8081,
-) inherits coi::profiles::base {
-
-  $puppet_master_bind_address = hiera('puppet_master_address', $::fqdn)
-  # installs puppet
-  # I think I want to assume a puppet 3.x install
-
-  # if this is not set, make sure nodes are all pointing at an apt/yum repo
-  # that has puppet > 3.2
-  if $puppetlabs_repo {
-    include puppet::repo::puppetlabs
-  }
-
-  include apache
-
-  # the puppetdb package should not be installed
-  # before our certificate is generated
-  Exec['Certificate_Check'] -> Package['puppetdb']
-
-  # we need to validate the puppetdb http connection
-  # and not the https one b/c will not have access to
-  # the certificate b/c we create it during the puppet
-  # run
-  Service['puppetdb'] -> Puppetdb_conn_validator['puppetdb_conn_http']
-  puppetdb_conn_validator { 'puppetdb_conn_http':
-    ensure          => present,
-    puppetdb_server => $puppet_master_bind_address,
-    puppetdb_port   => $puppetdb_port,
-    use_ssl         => false,
-    timeout         => 240,
-    notify          => Class['apache'],
-  }
-
-  # install puppet master
-  class { '::puppet::master':
-    certname    => $::fqdn,
-    autosign    => true,
-    modulepath  => '/etc/puppet/modules:/usr/share/puppet/modules',
-  }
-
-  # install puppetdb and postgresql
-  class { 'puppetdb':
-    listen_address     => $puppetdb_listen_address,
-    listen_port        => $puppetdb_port,
-    ssl_listen_address => $puppetdb_listen_address,
-    ssl_listen_port    => $puppetdb_ssl_port,
-    database_password  => 'datapass',
-    
-  }
-
-  # Configure the puppet master to use puppetdb.
-  class { 'puppetdb::master::config':
-    puppetdb_server   => $puppet_master_bind_address,
-    puppetdb_port     => $puppetdb_ssl_port,
-    restart_puppet    => false,
-    # I only want to validate with http
-    strict_validation => false,
-  }
-
-  # Add puppetdb storeconfigs settings to puppet.conf [main] also
-  # so that puppet agent runs will use storeconfigs
-  Ini_setting {
-    path    => $::puppet::params::puppet_conf,
-    require => File[$::puppet::params::puppet_conf],
-    notify  => Service['httpd'],
-    section => 'main',
-    ensure  => present,
-  }
-
-  ini_setting { 'puppetmainstoreconfigs':
-    setting => 'storeconfigs',
-    value   => 'true',
-  }
-
-  ini_setting { 'puppetmainstoreconfigs_backend':
-    setting => 'storeconfigs_backend',
-    value   => 'puppetdb',
-  }
+# and all this before cobbler, for now
+  Class['coi::profiles::puppet::masterpuppetdb'] -> Service<|title == cobbler|>
 
 }

--- a/manifests/profiles/puppet/masterpassenger.pp
+++ b/manifests/profiles/puppet/masterpassenger.pp
@@ -1,0 +1,122 @@
+# Class to configure a puppetmaster with passenger and Apache integration
+#  - assumes trusty native packages for puppet, passenger, and Apache
+#
+
+class coi::profiles::puppet::masterpassenger(
+  $modulepath = '/etc/puppet/modules:/usr/share/puppet/modules',
+  $pluginsync = true,
+  $autosign   = true,
+  $certname   = hiera('puppet_master_address', $::fqdn),
+  $manifest   = '/etc/puppet/manifests/site.pp',
+) {
+
+  package { 'puppet-common':
+    ensure => present,
+  }
+
+  package { 'puppet':
+    ensure  => present,
+    require => Package['puppet-common'],
+  }
+
+  package { 'puppetmaster-common':
+    ensure => present,
+  }
+
+  package { 'puppetmaster-passenger':
+    ensure  => present,
+    require => Package['puppetmaster-common'],
+  }
+
+#
+# build the Apache vhost from a template
+  file { "40-puppet-$certname.conf":
+    ensure  => present,
+    path    => "/etc/apache2/sites-available/40-puppet-$certname.conf",
+    content => template('coi/puppetmaster.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require => [Package['httpd'], Package['puppetmaster-passenger']],
+    notify  => Service['httpd'],
+  }
+
+  file{ "40-puppet-$::fqdn.conf symlink":
+    ensure  => link,
+    path    => "/etc/apache2/sites-enabled/40-puppet-$certname.conf",
+    target  => "/etc/apache2/sites-available/40-puppet-$certname.conf",
+    require => File["40-puppet-$certname.conf"],
+    notify  => Service['httpd'],
+  }
+
+#
+# load basic modules needed for Apache with Passenger
+
+  define modulelink {
+    file { "${title} load":
+      ensure => link,
+      path   => "/etc/apache2/mods-enabled/${title}.load",
+      target => "/etc/apache2/mods-available/${title}.load",
+      notify => Service['httpd'],
+    }
+  }
+
+  define conflink {
+    file { "${title} conf":
+      ensure => link,
+      path   => "/etc/apache2/mods-enabled/${title}.conf",
+      target => "/etc/apache2/mods-available/${title}.conf",
+      notify => Service['httpd'],
+    }
+  }
+
+  # socache_shmcb is needed for ssl
+  # access_compat is needed for Apache 2.2 style configs since we use 2.4
+  modulelink { [ "socache_shmcb",
+    "headers",
+    "passenger",
+    "ssl",
+    "access_compat" ]: }
+
+  conflink { [ "passenger", "ssl" ]: }
+
+#
+# basic puppet ini settings needed
+  Ini_setting {
+    path    => '/etc/puppet/puppet.conf',
+    require => Package['puppet'],
+    notify  => Service['httpd'],
+    section => 'master',
+  }
+
+  ini_setting {'puppetmastermodulepath':
+    ensure  => present,
+    setting => 'modulepath',
+    value   => $modulepath,
+  }
+
+  ini_setting {'puppetmastermanifest':
+    ensure  => present,
+    setting => 'manifest',
+    value   => $manifest,
+  }
+
+  ini_setting {'puppetmasterautosign':
+    ensure  => present,
+    setting => 'autosign',
+    value   => $autosign,
+  }
+
+  ini_setting {'puppetmastercertname':
+    ensure  => present,
+    setting => 'certname',
+    value   => $certname,
+  }
+
+  ini_setting {'puppetmasterpluginsync':
+    ensure  => present,
+    setting => 'pluginsync',
+    value   => $pluginsync,
+  }
+
+}

--- a/manifests/profiles/puppet/masterpuppetdb.pp
+++ b/manifests/profiles/puppet/masterpuppetdb.pp
@@ -1,0 +1,60 @@
+# Class to configure puppetdb and a puppetmaster to use that puppetdb
+#  - assumes that puppetdb and puppetmaster are colocated
+#  - assumes trusty native packages for puppet w/ supplemental puppetdb
+#      packages from the Cisco repo
+#
+
+class coi::profiles::puppet::masterpuppetdb(
+  $puppetdb_listen_address    = '0.0.0.0',
+  $puppetdb_port              = 8083,
+  $puppetdb_ssl_port          = 8081,
+  $puppetdb_database_password = 'datapass',
+  $puppet_master_bind_address = hiera('puppet_master_address', $::fqdn),
+) {
+
+#
+# install puppetdb and postgresql
+  class { 'puppetdb':
+    listen_address     => $puppetdb_listen_address,
+    listen_port        => $puppetdb_port,
+    ssl_listen_address => $puppetdb_listen_address,
+    ssl_listen_port    => $puppetdb_ssl_port,
+    database_password  => $puppetdb_database_password,
+  }
+
+#
+# configure puppet to use puppetdb
+  class { 'puppetdb::master::config':
+    puppetdb_server   => $puppet_master_bind_address,
+    puppetdb_port     => $puppetdb_ssl_port,
+    restart_puppet    => false,
+    # only validate with http
+    strict_validation => false,
+  }
+
+#
+# configure storeconfigs and reports with puppetdb
+  Ini_setting {
+    path    => '/etc/puppet/puppet.conf',
+    require => [Package['puppet'], Package['puppetdb']],
+    notify  => Service['httpd'],
+    section => 'main',
+    ensure  => present,
+  }
+
+  ini_setting { 'puppetmainstoreconfigs':
+    setting => 'storeconfigs',
+    value   => 'true',
+  }
+
+  ini_setting { 'puppetmainstoreconfigs_backend':
+    setting => 'storeconfigs_backend',
+    value   => 'puppetdb',
+  }
+
+  ini_setting { 'puppetmasterreports':
+    setting => 'reports',
+    value   => 'store,puppetdb',
+    section => 'master',
+  }
+}

--- a/templates/puppetmaster.erb
+++ b/templates/puppetmaster.erb
@@ -1,0 +1,49 @@
+# This Apache 2 virtual host config shows how to use Puppet as a Rack
+# application via Passenger. See
+# http://docs.puppetlabs.com/guides/passenger.html for more information.
+
+# You can also use the included config.ru file to run Puppet with other Rack
+# servers instead of Passenger.
+
+# you probably want to tune these settings
+PassengerHighPerformance on
+PassengerMaxPoolSize 12
+PassengerPoolIdleTime 1500
+# PassengerMaxRequests 1000
+PassengerStatThrottleRate 120
+
+Listen 8140
+
+<VirtualHost *:8140>
+        SSLEngine on
+        SSLProtocol -ALL +SSLv3 +TLSv1
+        SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
+
+        SSLCertificateFile      /var/lib/puppet/ssl/certs/<%= @certname %>.pem
+        SSLCertificateKeyFile   /var/lib/puppet/ssl/private_keys/<%= @certname %>.pem
+        SSLCertificateChainFile /var/lib/puppet/ssl/certs/ca.pem
+        SSLCACertificateFile    /var/lib/puppet/ssl/certs/ca.pem
+        # If Apache complains about invalid signatures on the CRL, you can try disabling
+        # CRL checking by commenting the next line, but this is not recommended.
+        SSLCARevocationFile     /var/lib/puppet/ssl/ca/ca_crl.pem
+        SSLVerifyClient optional
+        SSLVerifyDepth  1
+        # The `ExportCertData` option is needed for agent certificate expiration warnings
+        SSLOptions +StdEnvVars +ExportCertData
+
+        # This header needs to be set if using a loadbalancer or proxy
+        RequestHeader unset X-Forwarded-For
+
+        RequestHeader set X-SSL-Subject %{SSL_CLIENT_S_DN}e
+        RequestHeader set X-Client-DN %{SSL_CLIENT_S_DN}e
+        RequestHeader set X-Client-Verify %{SSL_CLIENT_VERIFY}e
+
+        DocumentRoot /usr/share/puppet/rack/puppetmasterd/public/
+        RackBaseURI /
+        <Directory /usr/share/puppet/rack/puppetmasterd/>
+                Options None
+                AllowOverride None
+                Order allow,deny
+                allow from all
+        </Directory>
+</VirtualHost>


### PR DESCRIPTION
Redo the composition layer of puppet / passenger / puppetdb integration
to align better with the trusty packages and the two-step puppet setup
process we use with setup.pp followed by site.pp.

Closes-Bug: #1311218
