### PR TITLE
Update power_type for trusty

### DIFF
--- a/manifests/cobbler_node.pp
+++ b/manifests/cobbler_node.pp
@@ -18,7 +18,7 @@
 #   [power_password]
 #      (optional) Password of 'power_user'. Defaults to password'
 #   [power_type]
-#     (optional) Type of power control used. Defaults to ipmitool.
+#     (optional) Type of power control used. Defaults to ipmilan.
 #
 define coi::cobbler_node(
   $node_type,
@@ -28,7 +28,7 @@ define coi::cobbler_node(
   $power_id       = undef,
   $power_user     = 'admin',
   $power_password = 'password',
-  $power_type     = 'ipmitool'
+  $power_type     = 'ipmilan'
 ) {
 
   cobbler::node { $name:


### PR DESCRIPTION
The combination of fence-agents and cobbler shipped in Ubuntu trusty
uses different names for selecting power types than were used with
Ubuntu precise. Update cobbler node definition to reflect new names.

Closes-Bug: #1325030
